### PR TITLE
Create user bourbon

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -65,7 +65,7 @@ function Home() {
       </div>
       <div className="d-flex flex-wrap">
         {bourbons.map((bourbon) => (
-          <BourbonCard bourbonObj={bourbon} key={bourbon.id} />
+          <BourbonCard bourbonObj={bourbon} key={bourbon.id} onUpdate={getAllBourbons} />
         ))}
       </div>
     </div>

--- a/src/components/BourbonCard.js
+++ b/src/components/BourbonCard.js
@@ -3,14 +3,12 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Card } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-import { addUserBourbon, getUserBourbons } from '../api/userBourbonData';
+import { addUserBourbon } from '../api/userBourbonData';
 import { checkUser } from '../api/userData';
 import { useAuth } from '../utils/context/authContext';
 
 export default function BourbonCard({ bourbonObj, userBourbonObj, onUpdate }) {
-  const [userBourbons, setUserBourbons] = useState([]);
   const [loggedInUserId, setLoggedInUserId] = useState(0);
-  const [bourbonOnUserList, setBourbonOnUserList] = useState(false);
   const { user } = useAuth();
 
   const getUserProfile = () => {
@@ -23,33 +21,6 @@ export default function BourbonCard({ bourbonObj, userBourbonObj, onUpdate }) {
     getUserProfile();
   }, []);
 
-  useEffect(() => {
-    if (loggedInUserId) {
-      getUserBourbons(loggedInUserId).then(setUserBourbons);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (userBourbons.length > 0) {
-      const isOnList = userBourbons.some((userBourbon) => userBourbon.bourbonId === bourbonObj.id);
-      setBourbonOnUserList(isOnList);
-    }
-  }, [userBourbons, bourbonObj]);
-
-  useEffect(() => {
-    console.warn('userBourbons', userBourbons);
-    console.warn('bourbononuserlist after state update', bourbonOnUserList);
-  });
-
-  // const isBourbonOnUserList = () => {
-  //         return userBourbons.some((userBourbon) => {
-  //       const isOnList = userBourbon.bourbonId === bourbonObj.id;
-  //       console.warn('isonlist', isOnList)
-  //       return isOnList
-  //     });
-  //    };
-
-  // const bourbonOnUserList = isBourbonOnUserList();
   const addBourbonToMyCollection = () => {
     const payload = { ...userBourbonObj, userId: loggedInUserId, bourbonId: bourbonObj.id, openBottle: false, emptyBottle: false };
     addUserBourbon(payload).then(() => {
@@ -58,7 +29,7 @@ export default function BourbonCard({ bourbonObj, userBourbonObj, onUpdate }) {
   };
 
   const renderButtons = () => {
-    if (bourbonOnUserList) {
+    if (userBourbonObj && userBourbonObj.userId === loggedInUserId) {
       return (
         <>
           <Button variant="primary">Closed</Button>
@@ -67,7 +38,7 @@ export default function BourbonCard({ bourbonObj, userBourbonObj, onUpdate }) {
         </>
       );
     }
-    if (userBourbonObj && !bourbonOnUserList) {
+    if (userBourbonObj) {
       return <Button variant="primary">Request Trade</Button>;
     }
     return (
@@ -99,6 +70,7 @@ BourbonCard.propTypes = {
     }).isRequired,
   }).isRequired,
   userBourbonObj: PropTypes.shape({
+    userId: PropTypes.number,
     bourbon: PropTypes.shape({
       image: PropTypes.string,
       name: PropTypes.string,


### PR DESCRIPTION
## Description
- added functionality for users to add bourbons to their collection (create userBourbon)
- added logic to show the right bourbon card buttons depending one which page the user is on: for browse page, bourbon card show "add to my collection"; for any other user's collection page, bourbon card shows request trade; for my collection page, bourbon card shows toggles and remove from collection options

## Related Issue
#31 

## Motivation and Context
This change allows users to add bourbons to their collection.

## How Can This Be Tested?
Log in
Click Add to Collection on a bourbon
Confirm bourbon is now in collection

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
