### PR TITLE
set up view pending trade requests

### DIFF
--- a/src/app/tradeRequest/page.js
+++ b/src/app/tradeRequest/page.js
@@ -1,11 +1,40 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getPendingTradeRequests } from '@/api/tradeRequestData';
+import { useAuth } from '@/utils/context/authContext';
+import { checkUser } from '@/api/userData';
 import ActiveTradeRequestCard from '../../components/ActiveTradeRequestCard';
 
 export default function TradeRequest() {
+  const [pendingTradeRequests, setPendingTradeRequests] = useState([]);
+  // const [loggedInProfile, setLoggedInProfile] = useState({});
+  const { user } = useAuth();
+
+  // const getUserProfile = () => {
+  //   checkUser(user.uid).then(setLoggedInProfile);
+  // };
+
+  // useEffect(() => {
+  //   getUserProfile();
+  // }, [])
+
+  const getAllPendingTradeRequests = () => {
+    checkUser(user.uid).then((backendUser) => {
+      getPendingTradeRequests(backendUser.id).then(setPendingTradeRequests);
+    });
+  };
+
+  useEffect(() => {
+    getAllPendingTradeRequests();
+  }, []);
+
   return (
     <div>
       Trade Request Page
-      <ActiveTradeRequestCard />
+      {pendingTradeRequests.map((pendingTradeRequest) => (
+        <ActiveTradeRequestCard pendingTradeRequestObj={pendingTradeRequest} key={pendingTradeRequest.id} />
+      ))}
     </div>
   );
 }

--- a/src/components/ActiveTradeRequestCard.js
+++ b/src/components/ActiveTradeRequestCard.js
@@ -1,5 +1,33 @@
-import React from 'react';
+'use client';
 
-export default function ActiveTradeRequestCard() {
-  return <div>Active Trade Request Card Component</div>;
+import React from 'react';
+import { Button, Card } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+export default function ActiveTradeRequestCard({ pendingTradeRequestObj }) {
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Text>
+          {pendingTradeRequestObj.requestingUser.username} requests to trade their {pendingTradeRequestObj.requestingFromBourbon.name} for your {pendingTradeRequestObj.requestedFromBourbon.name}
+        </Card.Text>
+        <Button variant="primary">Accept</Button>
+        <Button variant="danger">Reject</Button>
+      </Card.Body>
+    </Card>
+  );
 }
+
+ActiveTradeRequestCard.propTypes = {
+  pendingTradeRequestObj: PropTypes.shape({
+    requestingUser: PropTypes.shape({
+      username: PropTypes.string,
+    }).isRequired,
+    requestingFromBourbon: PropTypes.shape({
+      name: PropTypes.string,
+    }).isRequired,
+    requestedFromBourbon: PropTypes.shape({
+      name: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+};

--- a/src/components/forms/TradeRequestModalForm.js
+++ b/src/components/forms/TradeRequestModalForm.js
@@ -64,7 +64,6 @@ export default function TradeRequestModalForm({ userBourbonObj, onClose }) {
 
   return (
     <Modal show>
-      {console.warn('userbourbonobj', userBourbonObj)}
       <Modal.Header>
         <Modal.Title className="modal-heading">Trade Request</Modal.Title>
       </Modal.Header>


### PR DESCRIPTION
## Description
- set up ActiveTradeRequestCard component
- set up tradeRequest page to get all pending trade requests for the logged in user

## Related Issue
#17 

## Motivation and Context
This change will allow logged in users to view any pending trade requests from other users

## How Can This Be Tested?
Login
Navigate to My Profile
Click View Trade Requests
Confirm you can see Pending Trade Requests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
