### PR TITLE
set up update traderequest

### DIFF
--- a/src/app/tradeRequest/page.js
+++ b/src/app/tradeRequest/page.js
@@ -8,16 +8,7 @@ import ActiveTradeRequestCard from '../../components/ActiveTradeRequestCard';
 
 export default function TradeRequest() {
   const [pendingTradeRequests, setPendingTradeRequests] = useState([]);
-  // const [loggedInProfile, setLoggedInProfile] = useState({});
   const { user } = useAuth();
-
-  // const getUserProfile = () => {
-  //   checkUser(user.uid).then(setLoggedInProfile);
-  // };
-
-  // useEffect(() => {
-  //   getUserProfile();
-  // }, [])
 
   const getAllPendingTradeRequests = () => {
     checkUser(user.uid).then((backendUser) => {
@@ -33,7 +24,7 @@ export default function TradeRequest() {
     <div>
       Trade Request Page
       {pendingTradeRequests.map((pendingTradeRequest) => (
-        <ActiveTradeRequestCard pendingTradeRequestObj={pendingTradeRequest} key={pendingTradeRequest.id} />
+        <ActiveTradeRequestCard pendingTradeRequestObj={pendingTradeRequest} key={pendingTradeRequest.id} onUpdate={getAllPendingTradeRequests} />
       ))}
     </div>
   );

--- a/src/components/ActiveTradeRequestCard.js
+++ b/src/components/ActiveTradeRequestCard.js
@@ -3,16 +3,50 @@
 import React from 'react';
 import { Button, Card } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import { updateTradeRequest } from '@/api/tradeRequestData';
+import { addUserBourbon, deleteUserBourbon } from '@/api/userBourbonData';
 
-export default function ActiveTradeRequestCard({ pendingTradeRequestObj }) {
+export default function ActiveTradeRequestCard({ pendingTradeRequestObj, onUpdate }) {
+  const handleAccept = () => {
+    const payload = { ...pendingTradeRequestObj, pending: false, approved: true };
+    const addRequestingUserBourbonPayload = {
+      userId: pendingTradeRequestObj.requestingUser.id,
+      bourbonId: pendingTradeRequestObj.requestedFromBourbonId,
+      openBottle: false,
+      emptyBottle: false,
+    };
+    const addRequestedFromUserBourbonPayload = {
+      userId: pendingTradeRequestObj.requestedFromUser.id,
+      bourbonId: pendingTradeRequestObj.requestingBourbonId,
+      openBottle: false,
+      emptyBottle: false,
+    };
+    const operations = [updateTradeRequest(pendingTradeRequestObj.id, payload), addUserBourbon(addRequestingUserBourbonPayload), addUserBourbon(addRequestedFromUserBourbonPayload), deleteUserBourbon(pendingTradeRequestObj.requestedFromUserBourbonId), deleteUserBourbon(pendingTradeRequestObj.requestingUserBourbonId)];
+
+    Promise.all(operations).then(() => {
+      onUpdate();
+    });
+  };
+
+  const handleReject = () => {
+    const payload = { ...pendingTradeRequestObj, pending: false };
+    updateTradeRequest(pendingTradeRequestObj.id, payload).then(() => {
+      onUpdate();
+    });
+  };
+
   return (
     <Card>
       <Card.Body>
         <Card.Text>
           {pendingTradeRequestObj.requestingUser.username} requests to trade their {pendingTradeRequestObj.requestingFromBourbon.name} for your {pendingTradeRequestObj.requestedFromBourbon.name}
         </Card.Text>
-        <Button variant="primary">Accept</Button>
-        <Button variant="danger">Reject</Button>
+        <Button variant="primary" onClick={handleAccept}>
+          Accept
+        </Button>
+        <Button variant="danger" onClick={handleReject}>
+          Reject
+        </Button>
       </Card.Body>
     </Card>
   );
@@ -20,8 +54,13 @@ export default function ActiveTradeRequestCard({ pendingTradeRequestObj }) {
 
 ActiveTradeRequestCard.propTypes = {
   pendingTradeRequestObj: PropTypes.shape({
+    id: PropTypes.number,
     requestingUser: PropTypes.shape({
+      id: PropTypes.number,
       username: PropTypes.string,
+    }).isRequired,
+    requestedFromUser: PropTypes.shape({
+      id: PropTypes.number,
     }).isRequired,
     requestingFromBourbon: PropTypes.shape({
       name: PropTypes.string,
@@ -29,5 +68,11 @@ ActiveTradeRequestCard.propTypes = {
     requestedFromBourbon: PropTypes.shape({
       name: PropTypes.string,
     }).isRequired,
+    requestedFromBourbonId: PropTypes.number,
+    requestingBourbonId: PropTypes.number,
+    requestedFromUserBourbonId: PropTypes.number,
+    requestingUserBourbonId: PropTypes.number,
+    userBourbonId: PropTypes.number,
   }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };

--- a/src/components/forms/TradeRequestModalForm.js
+++ b/src/components/forms/TradeRequestModalForm.js
@@ -37,9 +37,12 @@ export default function TradeRequestModalForm({ userBourbonObj, onClose }) {
 
   const handleTradeRequestChange = (e) => {
     const { name, value } = e.target;
+    const selectedOption = e.target.options[e.target.selectedIndex];
+    const requestingUserBourbonId = selectedOption.getAttribute('data-requestinguserbourbonid');
     setTradeRequestFormInput((prevState) => ({
       ...prevState,
       [name]: name === 'requestingBourbonId' ? Number(value) : value,
+      requestingUserBourbonId,
     }));
   };
 
@@ -53,6 +56,7 @@ export default function TradeRequestModalForm({ userBourbonObj, onClose }) {
         requestedFromBourbonId: userBourbonObj.bourbonId,
         pending: true,
         approved: false,
+        requestedFromUserBourbonId: userBourbonObj.id,
       };
       addTradeRequest(payload).then(() => {
         onClose();
@@ -74,7 +78,7 @@ export default function TradeRequestModalForm({ userBourbonObj, onClose }) {
             <Form.Select aria-label="Default select example" name="requestingBourbonId" value={tradeRequestFormInput.requestingBourbonId} onChange={handleTradeRequestChange} required>
               <option value="">Select distillery</option>
               {loggedInUserBourbons.map((loggedInUserBourbon) => (
-                <option key={loggedInUserBourbon.bourbon.id} value={loggedInUserBourbon.bourbon.id}>
+                <option key={loggedInUserBourbon.bourbon.id} value={loggedInUserBourbon.bourbon.id} data-requestinguserbourbonid={loggedInUserBourbon.id}>
                   {loggedInUserBourbon.bourbon.name}
                 </option>
               ))}
@@ -96,6 +100,7 @@ export default function TradeRequestModalForm({ userBourbonObj, onClose }) {
 
 TradeRequestModalForm.propTypes = {
   userBourbonObj: PropTypes.shape({
+    id: PropTypes.number,
     userId: PropTypes.number,
     bourbonId: PropTypes.number,
   }).isRequired,


### PR DESCRIPTION
## Description
- set up ability for users to accept or reject trade requests
- when a user accepts a trade requested, the traded bourbon is removed from their collection and the new bourbon added
- this occurs for users who requested the trade as well
- when a user rejects a trade request, the pending trade request is removed from their trade request queue

## Related Issue
#18 

## Motivation and Context
This change allows users to review, accept and reject trade requests and update their collections appropriately.

## How Can This Be Tested?
Login
Navigate to another user's collection
Request a trade for another user's bourbon
Login as the user you requested the trade from
Accept or Reject the trade
If accepting, confirm the collections are updated with the traded bourbons and the traded bourbons are removed from the previous owner's collection
If rejected, confirm the pending trade request is removed from your trade request queue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
